### PR TITLE
fix plotting inconsistency

### DIFF
--- a/dgm_utils/training.py
+++ b/dgm_utils/training.py
@@ -16,7 +16,7 @@ from .model import BaseModel
 
 
 def train_epoch(
-    epoch: int, 
+    epoch: int,
     model: BaseModel,
     train_loader: DataLoader,
     optimizer: Optimizer,
@@ -46,9 +46,9 @@ def train_epoch(
 
 
 def eval_model(
-    epoch: int, 
-    model: BaseModel, 
-    data_loader: DataLoader, 
+    epoch: int,
+    model: BaseModel,
+    data_loader: DataLoader,
     conditional: bool = False,
     device: str = "cpu"
 ) -> defaultdict[str, float]:
@@ -63,7 +63,7 @@ def eval_model(
             else:
                 x = batch.to(device)
                 losses = model.loss(x)
-            
+
             for k, v in losses.items():
                 stats[k] += v.item() * x.shape[0]
 
@@ -100,6 +100,10 @@ def train_model(
     model = model.to(device)
     print("Start of the training")
 
+    test_loss = eval_model(0, model, test_loader, conditional, device)
+    for k in test_loss.keys():
+        test_losses[k].append(test_loss[k])
+
     for epoch in range(1, epochs + 1):
         train_loss = train_epoch(
             epoch, model, train_loader, optimizer, conditional, device, loss_key
@@ -110,6 +114,7 @@ def train_model(
 
         for k in train_loss.keys():
             train_losses[k].extend(train_loss[k])
+        for k in test_loss.keys():
             test_losses[k].append(test_loss[k])
 
         epoch_loss = np.mean(train_loss[loss_key])
@@ -118,7 +123,7 @@ def train_model(
                 samples = model.sample(n_samples)
                 if isinstance(samples, torch.Tensor):
                     samples = samples.cpu().detach().numpy()
-    
+
             clear_output(wait=True)
             title = f"Samples, epoch: {epoch}, {loss_key}: {epoch_loss:.3f}"
             if check_samples_is_2d(samples):
@@ -130,13 +135,13 @@ def train_model(
             clear_output(wait=True)
             print(f"Epoch: {epoch}, loss: {epoch_loss}")
             plot_training_curves(epoch, train_losses, test_losses, logscale_y, logscale_x)
-                    
+
     print("End of the training")
 
 
 
 def train_epoch_adversarial(
-    epoch: int, 
+    epoch: int,
     d_steps: int,
     gan: BaseModel,
     train_loader: DataLoader,
@@ -193,13 +198,13 @@ def train_adversarial(
 
     for epoch in range(1, epochs + 1):
         train_loss = train_epoch_adversarial(
-            epoch, 
-            d_steps, 
-            gan, 
-            train_loader, 
+            epoch,
+            d_steps,
+            gan,
+            train_loader,
             generator_optimizer,
             discriminator_optimizer,
-            device, 
+            device,
             generator_loss_key,
             discriminator_loss_key
         )
@@ -214,7 +219,7 @@ def train_adversarial(
                 samples = gan.sample(n_samples)
                 if isinstance(samples, torch.Tensor):
                     samples = samples.cpu().detach().numpy()
-    
+
             clear_output(wait=True)
             title = f"Samples, epoch: {epoch}, {generator_loss_key}: {g_epoch_loss:.3f}, {discriminator_loss_key}: {d_epoch_loss:.3f}"
             if check_samples_is_2d(samples):
@@ -226,5 +231,5 @@ def train_adversarial(
             clear_output(wait=True)
             print(f"Epoch: {epoch}, {generator_loss_key}: {g_epoch_loss:.3f}, {discriminator_loss_key}: {d_epoch_loss:.3f}")
             plot_training_curves(epoch, train_losses, None, logscale_y, logscale_x)
-                    
+
     print("End of the training")

--- a/dgm_utils/visualize.py
+++ b/dgm_utils/visualize.py
@@ -19,19 +19,16 @@ def plot_training_curves(
     logscale_y: bool = False,
     logscale_x: bool = False,
 ) -> None:
-    if test_losses is not None:
-        n_test = len(test_losses[list(train_losses.keys())[0]])
-        x_test = np.arange(n_test)
+    plt.figure()
 
     n_train = len(train_losses[list(train_losses.keys())[0]])
-    x_train = np.linspace(0, epochs - 1, n_train)
-    
-
-    plt.figure()
+    x_train = np.linspace(0, epochs, n_train)
     for key, value in train_losses.items():
         plt.plot(x_train, value, label=key + "_train")
 
     if test_losses is not None:
+        n_test = len(test_losses[list(test_losses.keys())[0]])
+        x_test = np.arange(n_test)
         for key, value in test_losses.items():
             plt.plot(x_test, value, label=key + "_test")
 


### PR DESCRIPTION
This PR corrects two plotting issues that caused visual inaccuracies in training progress:

**Before:** The first epoch's metrics were incorrectly consolidated into a single x-axis point, making it appear as a vertical line rather than a proper curve. Subsequent epochs had off-by-one numbering errors.

<img width="640" height="480" alt="as_is_1" src="https://github.com/user-attachments/assets/e67c68bc-a460-419f-a266-d34a0a96c9fc" />
<img width="640" height="480" alt="as_is_2" src="https://github.com/user-attachments/assets/66a54efe-1a99-42a6-bf16-0017d4cc2c10" />

**After:** 
- First epoch history now plots correctly across multiple x-values
- Epoch numbering is accurate for all subsequent iterations

<img width="640" height="480" alt="to_be_1" src="https://github.com/user-attachments/assets/6b0bb286-38e1-4ccd-8546-835dec17c49b" />
<img width="640" height="480" alt="to_be_2" src="https://github.com/user-attachments/assets/df0cf079-286e-40e6-9c9e-b96213d0f0b8" />

This ensures training visualizations properly reflect the actual progression of metrics.
